### PR TITLE
Enable profile editing with avatar upload and display

### DIFF
--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -27,3 +27,13 @@ textarea {
   border: none;
   background-color: #f4f4f4;
 }
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.file {
+  margin-top: 15px;
+}

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -4,4 +4,24 @@ class ProfilesController < ApplicationController
   def show
     @profile = current_user.profile
   end
+
+  def edit
+    @profile = current_user.prepare_profile
+  end
+
+  def update
+    @profile = current_user.prepare_profile
+    @profile.assign_attributes(profile_params)
+    if @profile.save
+      redirect_to profile_path, notice: 'Profile updated!'
+    else
+      flash.now[:error] = 'Update failed'
+      render :edit
+    end
+  end
+
+  private
+  def profile_params
+    params.require(:profile).permit(:nickname, :avatar)
+  end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,3 +1,4 @@
 class Profile < ApplicationRecord
   belongs_to :user
+  has_one_attached :avatar
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,22 @@ class User < ApplicationRecord
 
   has_many :boards, dependent: :destroy
   has_one :profile, dependent: :destroy
+
+  delegate :nickname, to: :profile, allow_nil: true
+
+  def prepare_profile
+    profile || build_profile
+  end
+
+  def display_name
+    profile&.nickname || self.email.split('@').first
+  end
+
+  def avatar_image
+    if profile&.avatar&.attached?
+      profile.avatar
+    else
+      'face.png'
+    end
+  end
 end

--- a/app/views/commons/_board.html.haml
+++ b/app/views/commons/_board.html.haml
@@ -11,4 +11,4 @@
   .board_card_content
     %p= board.description
   .board_card_img
-    = image_tag 'face.png'
+    = image_tag board.user.avatar_image

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,7 +20,7 @@
       = link_to 'Boards', root_path, class: 'header_text'
       - if user_signed_in?
         .dropdown
-          = image_tag 'face.png', class: 'avatar'
+          = image_tag current_user.avatar_image, class: 'avatar'
           .dropdown_content
             = link_to 'Profile', profile_path
             = link_to 'Log out', destroy_user_session_path, data: { method: 'delete' }

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -1,0 +1,16 @@
+.container
+  .card
+    = form_with(model: @profile, url: profile_path, method: :patch, data: { turbo: false }) do |f|
+      .card_body
+        %h2 Profile
+        %ul
+          - @profile.errors.full_messages.each do |message|
+            %li= message
+        .field
+          = f.label :nickname, 'Name'
+          = f.text_field :nickname, class: 'text'
+        .field
+          = f.label :avatar, 'Avatar'
+          = f.file_field :avatar, class: 'file'
+      .card_footer
+        = f.submit 'Submit', class: 'btn-primary full-width-btn'

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,12 +1,10 @@
 .card
   .profile
     .profile_image
-      = image_tag 'face.png'
+      = image_tag current_user.avatar_image
     .profile_info
       .profile_name
         .profile_displayName
-          名前
+          = current_user.display_name
         .profile_button
           = link_to 'Edit', edit_profile_path
-      .profile_intro
-        自己紹介


### PR DESCRIPTION
## 概要
プロフィール編集機能にアバター画像のアップロード対応を追加し、アバター画像やプロフィール情報を各所の画面で表示できるようにしました。

### ✅ 主な変更点
- Profile編集画面でAvatarをアップロードできるよう対応
- View（ex: header, Profile/show etc）にてAvatarなどProfile情報を表示
- ProfilesController の update 処理をリファクタリングし、画像含む更新に対応

### 📷 動作確認
- アバター画像を選択してプロフィールを更新できる
   <img width="430" alt="image" src="https://github.com/user-attachments/assets/014bd2b0-2124-44f0-99ee-76fe09d60a79" />
- プロフィール情報が更新後も正しく表示される
- アップロードされた画像が適切に表示される
   <img width="430" alt="image" src="https://github.com/user-attachments/assets/8e94d261-bb86-4ed1-b096-9a15c05ad7e2" />