### PR TITLE
Add eyecatch image support for tasks

### DIFF
--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -41,5 +41,5 @@ textarea {
 }
 
 .file {
-  margin-top: 15px;
+  margin: 15px 0 40px;
 }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -52,7 +52,7 @@ class TasksController < ApplicationController
 
   private
   def task_params
-    params.require(:task).permit(:title, :content, :deadline, :board_id)
+    params.require(:task).permit(:title, :content, :deadline, :eyecatch, :board_id)
   end
 
   def set_task

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,6 +9,7 @@ class Task < ApplicationRecord
 
   belongs_to :user
   belongs_to :board
+  has_one_attached :eyecatch
 
   private
 

--- a/app/views/boards/show.html.haml
+++ b/app/views/boards/show.html.haml
@@ -6,8 +6,9 @@
       - @tasks.each do |task|
         = link_to task_path(task) do
           .task
-            .eyecatch
-              = image_tag 'eyecatch.png'
+            - if task.eyecatch.attached?
+              .eyecatch
+                = image_tag task.eyecatch
             .task_header
               %h5= task.title
             .task_content

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -7,6 +7,9 @@
           - task.errors.full_messages.each do |message|
             %li= message
         .field
+          = f.label :eyecatch, 'Eyecatch'
+          = f.file_field :eyecatch
+        .field
           = f.label :title, 'Name'
           = f.text_field :title, class: 'text'
         .field

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -8,7 +8,7 @@
             %li= message
         .field
           = f.label :eyecatch, 'Eyecatch'
-          = f.file_field :eyecatch
+          = f.file_field :eyecatch, class: 'file'
         .field
           = f.label :title, 'Name'
           = f.text_field :title, class: 'text'

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -10,8 +10,9 @@
               = link_to 'Edit', edit_task_path(@task)
               = link_to 'Delete', task_path(@task), data: { method: 'delete', confirm: '本当に削除してもよろしいですか？' }
 
-      .eyecatch
-        = image_tag 'eyecatch.png'
+      - if @task.eyecatch.attached?
+        .eyecatch
+          = image_tag @task.eyecatch
       .task_detail_content
         %p= @task.content
       .task_detail_comment


### PR DESCRIPTION
## 変更内容
Taskにアイキャッチ画像を追加・表示できる機能を導入しました。
主な更新内容は以下の通りです：

- Taskモデルとフォームにeyecatchを追加
   - ActiveStorage を使って eyecatch 属性を追加し、ファイルアップロードに対応
   - タスク作成・編集フォームにファイル選択フィールドを追加
- アップロードされたeyecatchの表示
   - boardとtaskの show ビューで、eyecatch画像がある場合に表示されるよう変更
- スタイルの更新
   - eyecatchのファイルアップロードフィールドにスタイルを適用し、ユーザー体験を向上
   - レイアウトの整合性を保つため、関連するSCSSも調整

## 動作確認
### Task登録フォーム
<img width="827" alt="image" src="https://github.com/user-attachments/assets/a39d2f9b-3de4-44c4-bacf-b376f16fed38" />

### Board詳細画面でのeyecatch表示
<img width="827" alt="image" src="https://github.com/user-attachments/assets/e5d79444-fcef-4e6e-a062-c3e0bb27f38c" />

### Task詳細画面でのeyecatch表示
<img width="827" alt="image" src="https://github.com/user-attachments/assets/6b1caf55-dffe-44ad-8bf0-5086b1990767" />