### PR TITLE
コメント機能の実装 & コメント数表示

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,7 +58,7 @@ h2 {
   border: none;
   color: #a94442;
   padding: 1.5rem 1.3rem 1rem;
-  margin-top: 1.5rem;
+  margin: 1.5rem 0;
   border-radius: 5px;
 
   h2 {
@@ -72,6 +72,23 @@ h2 {
     li {
       margin: 0.25rem 0;
       line-height: 1.2rem;
+      font-size: 14px;
     }
+  }
+}
+
+ul.error {
+  background-color: #fff4f4;
+  color: #a94442;
+  padding: 0.8rem 1.2rem;
+  margin: 1.5rem 0;
+  border-radius: 8px;
+  list-style: none;
+
+  li {
+    position: relative;
+    margin: 0.4rem 0;
+    line-height: 1.4;
+    font-size: 14px;
   }
 }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,10 +4,22 @@ class CommentsController < ApplicationController
     @comment = @task.comments.build
   end
 
+  def create
+    @task = Task.find(params[:task_id])
+    @comment = current_user.comments.build(comment_param)
+    @comment.task = @task
+    if @comment.save
+      redirect_to task_path(@task), notice: 'Added comment!'
+    else
+      flash.now[:error] = 'Comment could not be submitted'
+      render :new
+    end
+  end
+
 
   private
 
   def comment_param
-    params.require(:comment).permit(:content)
+    params.require(:comment).permit(:content, :task_id)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,11 +1,11 @@
 class CommentsController < ApplicationController
+before_action :set_task
+
   def new
-    @task = Task.find(params[:task_id])
     @comment = @task.comments.build
   end
 
   def create
-    @task = Task.find(params[:task_id])
     @comment = current_user.comments.build(comment_param)
     @comment.task = @task
     if @comment.save
@@ -18,6 +18,10 @@ class CommentsController < ApplicationController
 
 
   private
+
+  def set_task
+    @task = Task.find(params[:task_id])
+  end
 
   def comment_param
     params.require(:comment).permit(:content, :task_id)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,13 @@
+class CommentsController < ApplicationController
+  def new
+    @task = Task.find(params[:task_id])
+    @comment = @task.comments.build
+  end
+
+
+  private
+
+  def comment_param
+    params.require(:comment).permit(:content)
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -24,6 +24,7 @@ class TasksController < ApplicationController
   end
 
   def show
+    @comments = @task.comments
   end
 
   def edit

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :task
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,7 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :task
+
+  validates :content, presence: true
+
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,5 +3,6 @@ class Comment < ApplicationRecord
   belongs_to :task
 
   validates :content, presence: true
+  validates :content, length: { minimum: 1, maximum: 256 }
 
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -10,7 +10,7 @@ class Task < ApplicationRecord
   belongs_to :user
   belongs_to :board
   has_one_attached :eyecatch
-  mas_many :comments, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   private
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -10,6 +10,7 @@ class Task < ApplicationRecord
   belongs_to :user
   belongs_to :board
   has_one_attached :eyecatch
+  mas_many :comments, dependent: :destroy
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   has_many :boards, dependent: :destroy
   has_many :tasks, dependent: :destroy
+  has_many :comments, dependent: :destroy
   has_one :profile, dependent: :destroy
 
   delegate :nickname, to: :profile, allow_nil: true

--- a/app/views/boards/_form.html.haml
+++ b/app/views/boards/_form.html.haml
@@ -3,9 +3,10 @@
     = form_with(model: board, local: true) do |f|
       .card_body
         %h2 New Board
-        %ul
-          - board.errors.full_messages.each do |message|
-            %li= message
+        - if board.errors.any?
+          %ul.error
+            - board.errors.full_messages.each do |message|
+              %li= message
         .field
           = f.label :title, 'Name'
           = f.text_field :title, class: 'text'

--- a/app/views/boards/show.html.haml
+++ b/app/views/boards/show.html.haml
@@ -17,7 +17,7 @@
               .task_img
                 = image_tag task.user.profile.avatar
               .task_comment
-                %span 23
+                %span= task.comments.count
                 = image_tag 'comment.svg'
 
       %p.new_card

--- a/app/views/comments/_form.html.haml
+++ b/app/views/comments/_form.html.haml
@@ -1,0 +1,13 @@
+.container
+  .card
+    = form_with(model: [@task, @comment], local: true) do |f|
+      .card_body
+        %h2 New Comment
+        %ul
+          - comment.errors.full_messages.each do |message|
+            %li= message
+        .field
+          = f.label :content
+          = f.text_area :content, class: 'text'
+      .card_footer
+        = f.submit 'Submit', class: 'btn-primary full-width-btn'

--- a/app/views/comments/_form.html.haml
+++ b/app/views/comments/_form.html.haml
@@ -1,11 +1,12 @@
 .container
   .card
-    = form_with(model: [@task, @comment], local: true) do |f|
+    = form_with(model: [@task, @comment], data: { turbo: false }) do |f|
       .card_body
         %h2 New Comment
-        %ul
-          - comment.errors.full_messages.each do |message|
-            %li= message
+        - if @comment.errors.any?
+          %ul.error
+            - @comment.errors.full_messages.each do |message|
+              %li= message
         .field
           = f.label :content
           = f.text_area :content, class: 'text'

--- a/app/views/comments/new.html.haml
+++ b/app/views/comments/new.html.haml
@@ -1,0 +1,1 @@
+= render 'form', comment: @comment

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -3,14 +3,15 @@
     = form_with(model: [@board, task], local: true) do |f|
       .card_body
         %h2 New Card
-        %ul
-          - task.errors.full_messages.each do |message|
-            %li= message
+        - if task.errors.any?
+          %ul.error
+            - task.errors.full_messages.each do |message|
+              %li= message
         .field
           = f.label :eyecatch, 'Eyecatch'
           = f.file_field :eyecatch, class: 'file'
         .field
-          = f.label :title, 'Name'
+          = f.label :title, 'Title'
           = f.text_field :title, class: 'text'
         .field
           = f.label :content, 'Description'

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -17,15 +17,12 @@
         %p= @task.content
       .task_detail_comment
         %h3 Comment
-      .task_detail_comments
-        .task_detail_comments_img
-          = image_tag 'face.png'
-        .task_detail_comments_content
-          %p Successful businesses know the importance of building and maintaining good working. Successful businesses know the importanc
-      .task_detail_comments
-        .task_detail_comments_img
-          = image_tag 'face2.png'
-        .task_detail_comments_content
-          %p Successful businesses know the importance of building and maintaining good working. Successful businesses know the importanc
+      - @comments.each do |comment|
+        .task_detail_comments
+          .task_detail_comments_img
+            = image_tag comment.user.profile.avatar
+          .task_detail_comments_content
+            %p= comment.content
 
-    %p.new_comment + Add new comment
+    %p.new_comment
+      = link_to '+ Add new comment', new_task_comment_path(@task)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,9 @@ Rails.application.routes.draw do
     resources :tasks
   end
 
-  resources :tasks
+  resources :tasks do
+    resources :comments, only: [:new, :create]
+  end
 
   resource :profile, only: [:show, :edit, :update]
 

--- a/db/migrate/20250629061623_create_comments.rb
+++ b/db/migrate/20250629061623_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :comments do |t|
+      t.references :task, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.text :content, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_28_150137) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_29_061623) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -51,6 +51,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_28_150137) do
     t.index ["user_id"], name: "index_boards_on_user_id"
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.bigint "user_id", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_id"], name: "index_comments_on_task_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "profiles", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "nickname"
@@ -86,5 +96,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_28_150137) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "tasks"
+  add_foreign_key "comments", "users"
   add_foreign_key "tasks", "boards"
 end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## ✅ 概要

Taskに対するComment機能を新たに実装し、Task一覧画面に各TaskのComment数を表示できるようにしました。


### 🛠 実装内容
1. Commentモデルの作成とアソシエーションの設定
   - User, Task と Comment のリレーションを構築
   ```
   User has_many :comments
   Task has_many :comments
   Comment belongs_to :user, belongs_to :task
   ```
2. ルーティングの更新
   - コメントをタスクにネストしたルーティングに設定
      ```
       resources :tasks do resources :comments, only: [:new, :create] end
       ```
3. 新規作成画面の追加
   - comments#new アクションとビューファイルを作成
   - task詳細ページ からコメント投稿ページへリンクを追加
4. コメント投稿機能の実装
   - comments#create を実装し、バリデーション失敗時は render :new
   - 成功時は task_path(@task) にリダイレクト
5. コメントの表示
   - tasks#show ページで該当タスクのコメント一覧を表示
6. タスク一覧画面へのコメント数表示
   - tasks#index に各タスクの comments.count を表示
   - N+1防止のため includes(:comments) を使用（必要に応じて）


### 📸 UI 変更点
- tasks#index: コメント数のカラム追加（例: 💬 3）
- tasks#show: コメント一覧の表示、投稿リンク

### ✅ 動作確認
- タスク詳細ページからコメント投稿ができるか
   <img width="831" alt="image" src="https://github.com/user-attachments/assets/d7d15e19-ab6e-4379-b2aa-f1cbe8fa2104" />

- 空のコメントをバリデーションで弾いているか
   <img width="831" alt="image" src="https://github.com/user-attachments/assets/21bd98d0-90fc-494a-8f04-6de1faeea040" />

- コメント数が正しく表示されているか
   <img width="831" alt="image" src="https://github.com/user-attachments/assets/21677c44-e234-4a25-8c77-0da2612c89c6" />