### PR TITLE
Add dependent: :destroy to Board has_many :tasks association

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -4,7 +4,7 @@ class Board < ApplicationRecord
   validates :title, uniqueness: true
   validates :description, length: { maximum: 250 }
   belongs_to :user
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
 
   def avatar_img
     user.avatar_image


### PR DESCRIPTION
## 概要

`Board` を削除する際に、関連する `Task` も合わせて削除されるように `has_many :tasks, dependent: :destroy` を追加しました。

これにより、タスクを持つボードでも削除確認ダイアログの上で削除を許可し、DBエラーを回避します。

## 変更内容

- Board モデルに `dependent: :destroy` を追加


## 背景

元々、ボードにタスクがあると外部キー制約により削除できず、`PG::ForeignKeyViolation` エラーが発生していました。
本アプリでは、削除前に「本当に削除しますか？」の確認アラートを表示しているため、意図的な削除であることが明確。
そのため、関連タスクも一緒に削除されるように設定しました。


## 動作確認

- タスクが紐づくボードを削除 → 確認ダイアログを経て削除され、関連するタスクも同時に削除されることを確認


## 備考

- ユーザーへの誤削除防止は JavaScript の `confirm` アラートでカバーしています。
- 複雑な依存関係がない場合は、この方針で問題ないと判断しました。